### PR TITLE
🎨 Palette: Improve edit code button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Icon-only buttons accessibility pattern
+**Learning:** Found an icon-only button (edit code button) using only an emoji `✏️` without `aria-label` or `aria-hidden` tags. This creates a confusing experience for screen readers. This seems to be a common pattern in this app's static HTML pages.
+**Action:** Always verify that buttons containing only icons/emojis include `aria-label` with descriptive text and wrap the visual icon in `<span aria-hidden="true">`.

--- a/app/static/dashboard.html
+++ b/app/static/dashboard.html
@@ -18,7 +18,9 @@
                 <div class="code-display" title="Partagez ce code avec vos étudiants">
                     Code: <strong id="teacher-code-display">{{unique_code}}</strong>
                     <button id="edit-code-btn" class="btn btn-sm"
-                        style="padding: 2px 4px; font-size: 0.7em;">✏️</button>
+                        style="padding: 2px 4px; font-size: 0.7em;" aria-label="Modifier le code">
+                        <span aria-hidden="true">✏️</span>
+                    </button>
                 </div>
                 <div class="credits_display"
                     style="background: #e3f2fd; padding: 5px 10px; border-radius: 4px; margin-right: 10px;">


### PR DESCRIPTION
💡 What: The UX enhancement added: `aria-label` and `aria-hidden` tags to the "Edit Code" button in `dashboard.html`.

🎯 Why: The user problem it solves: The button previously only contained a ✏️ emoji, which screen readers would either read literally or skip, making the action unclear for visually impaired users.

📸 Before/After: Visuals remain identical. Tested and verified locally via Playwright screenshot.

♿ Accessibility: Any a11y improvements made: Makes the "Edit Code" action explicitly readable by assistive technologies by hiding the decorative emoji and providing clear context ("Modifier le code"). This sets a good precedent for other icon-only buttons in the application.

---
*PR created automatically by Jules for task [13012687784593302172](https://jules.google.com/task/13012687784593302172) started by @mohamedhousniphd*