### PR TITLE
🧹 Remove unused datetime import from app/database.py

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,6 @@
 import sqlite3
 from contextlib import contextmanager
 from typing import Optional
-from datetime import datetime
 import uuid
 
 


### PR DESCRIPTION
Removed the unused `datetime` import from `app/database.py` to improve code health and maintainability. verified that the code still compiles correctly.

---
*PR created automatically by Jules for task [9028850582190935279](https://jules.google.com/task/9028850582190935279) started by @mohamedhousniphd*