### PR TITLE
Make credit amount configurable during receipt approval

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -57,7 +57,8 @@ from app.models import (
     AnalyzeResponse,
     StatusResponse,
     ErrorResponse,
-    ImportFeedbackItem
+    ImportFeedbackItem,
+    ReceiptApprovalRequest
 )
 from app.services.wordcloud import create_wordcloud
 from app.services.deepseek import analyze_feedbacks
@@ -781,6 +782,7 @@ async def list_receipts(
 @app.post("/api/admin/receipts/{receipt_id}/approve")
 async def approve_receipt(
     receipt_id: int,
+    data: ReceiptApprovalRequest = Body(...),
     teacher: dict = Depends(get_current_teacher)
 ):
     """Approve a receipt and add credits (Admin only)."""
@@ -796,14 +798,13 @@ async def approve_receipt(
     if receipt['status'] == 'approved':
         return {"status": "success", "message": "Déjà approuvé"}
         
-    # Approve and add credits (e.g., 5 credits per valid payment)
-    # TODO: Make credit amount configurable or part of the request
-    CREDITS_PER_PAYMENT = 10 
+    # Approve and add credits
+    credits_to_add = data.amount
     
     update_receipt_status(receipt_id, 'approved')
-    add_credits(receipt['teacher_id'], CREDITS_PER_PAYMENT)
+    add_credits(receipt['teacher_id'], credits_to_add)
     
-    return {"status": "success", "message": f"Reçu validé, {CREDITS_PER_PAYMENT} crédits ajoutés"}
+    return {"status": "success", "message": f"Reçu validé, {credits_to_add} crédits ajoutés"}
 
 
 @app.post("/api/admin/receipts/{receipt_id}/reject")

--- a/app/models.py
+++ b/app/models.py
@@ -58,3 +58,7 @@ class ImportFeedbackItem(BaseModel):
     created_at: Optional[datetime] = None
     included_in_analysis: Optional[bool] = False
     emotion: Optional[int] = Field(None, ge=1, le=10)
+
+
+class ReceiptApprovalRequest(BaseModel):
+    amount: int = Field(10, ge=1, description="Number of credits to add")

--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -206,11 +206,29 @@
         }
 
         async function approveReceipt(id) {
-            if (!confirm('Valider ce paiement et ajouter 10 crédits ?')) return;
+            const amount = prompt('Nombre de crédits à ajouter :', '10');
+            if (amount === null) return;
+
+            const parsedAmount = parseInt(amount);
+            if (isNaN(parsedAmount) || parsedAmount <= 0) {
+                alert('Veuillez entrer un nombre valide supérieur à 0');
+                return;
+            }
+
+            if (!confirm(`Valider ce paiement et ajouter ${parsedAmount} crédits ?`)) return;
             try {
-                const response = await fetch(`/api/admin/receipts/${id}/approve`, { method: 'POST' });
-                if (response.ok) loadReceipts();
-            } catch (e) { alert('Erreur'); }
+                const response = await fetch(`/api/admin/receipts/${id}/approve`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ amount: parsedAmount })
+                });
+                if (response.ok) {
+                    loadReceipts();
+                } else {
+                    const error = await response.json();
+                    alert('Erreur: ' + (error.detail || 'Inconnue'));
+                }
+            } catch (e) { alert('Erreur de connexion'); }
         }
 
         async function rejectReceipt(id) {


### PR DESCRIPTION
The hardcoded credit amount for receipt approval (10) has been replaced with a configurable value. 

Changes include:
- A new Pydantic model `ReceiptApprovalRequest` in `app/models.py` for validating the request body.
- Updates to the `approve_receipt` endpoint in `app/main.py` to accept this model and apply the specified credits.
- An update to the admin dashboard (`app/static/admin.html`) to allow administrators to specify the number of credits to grant upon approval via a prompt.
- Server-side and client-side validation to ensure the amount is at least 1.

---
*PR created automatically by Jules for task [434454175775799891](https://jules.google.com/task/434454175775799891) started by @mohamedhousniphd*