### PR TITLE
🧹 Remove unused Cookie import in app/main.py

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -62,7 +62,7 @@ from app.models import (
 from app.services.wordcloud import create_wordcloud
 from app.services.deepseek import analyze_feedbacks
 from datetime import timedelta
-from fastapi import Cookie, Query
+from fastapi import Query
 
 # Initialize FastAPI app
 app = FastAPI(title="Feedny", version="1.0.0")


### PR DESCRIPTION
🎯 **What:** Removed the unused `Cookie` import from `fastapi` in `app/main.py` on line 65.
💡 **Why:** `Cookie` was imported but never used in the module, contributing to slight unnecessary overhead and clutter. Removing unused imports improves code readability and maintainability.
✅ **Verification:** Verified that the syntax of `app/main.py` is still correct using `python3 -m py_compile app/main.py`. The project currently does not have an automated test suite (`tests/` directory missing), but since the change is isolated to a single unused import statement, it is safe and does not break any functionality.
✨ **Result:** A cleaner import section with no unused dependencies.

---
*PR created automatically by Jules for task [16236730215687230425](https://jules.google.com/task/16236730215687230425) started by @mohamedhousniphd*