### PR TITLE
🧹 Remove unused `Literal` import from `app/models.py`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from datetime import datetime
-from typing import Optional, Literal
+from typing import Optional
 
 
 class FeedbackRequest(BaseModel):


### PR DESCRIPTION
🎯 **What:** The unused `Literal` import from the `typing` module was removed from `app/models.py`.
💡 **Why:** This improves code health by removing dead code, which reduces clutter and potential confusion for other developers reading the file.
✅ **Verification:** Verified that the syntax is still correct with `py_compile`. Since this is just an unused import, it has no impact on runtime functionality.
✨ **Result:** The code is cleaner, more readable, and maintains exactly the same functionality as before.

---
*PR created automatically by Jules for task [15384425271147024442](https://jules.google.com/task/15384425271147024442) started by @mohamedhousniphd*