### PR TITLE
🧹 Remove unused imports in app/services/pdf.py

### DIFF
--- a/app/services/pdf.py
+++ b/app/services/pdf.py
@@ -5,13 +5,13 @@ from datetime import datetime
 from typing import Optional
 
 from reportlab.lib.pagesizes import A4, landscape
-from reportlab.lib.units import inch, cm
+from reportlab.lib.units import cm
 from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.platypus import (
-    SimpleDocTemplate, Paragraph, Spacer, Image, Table, TableStyle
+    SimpleDocTemplate, Paragraph, Spacer, Image
 )
-from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_JUSTIFY
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from PIL import Image as PILImage


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`inch`, `Table`, `TableStyle`, `TA_LEFT`) from `app/services/pdf.py`.
💡 **Why:** To improve code health, maintainability, and readability by cleaning up dead code.
✅ **Verification:** Verified with `python3 -m py_compile` and tested that `PYTHONPATH=. pytest` found no test suite issues. Received passing automated code review.
✨ **Result:** A cleaner imports section in `app/services/pdf.py` without any unused items hanging around.

---
*PR created automatically by Jules for task [14855406214452503662](https://jules.google.com/task/14855406214452503662) started by @mohamedhousniphd*