### PR TITLE
🧹 Remove unused `FileResponse` import from `app/main.py`

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from fastapi import FastAPI, Request, Response, HTTPException, Depends, Form, Body, File, UploadFile
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, FileResponse
+from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import ValidationError
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused `FileResponse` import from `app/main.py`.

💡 **Why:** How this improves maintainability
Removing unused imports reduces clutter, prevents potential naming conflicts, and ensures that tools/linters reading the file aren't confused by unneeded imports. It simplifies the codebase and improves overall readability.

✅ **Verification:** How you confirmed the change is safe
- Confirmed `FileResponse` is not used anywhere else in `app/main.py`.
- Ran `python3 -m py_compile app/main.py` which completed successfully with no syntax errors.

✨ **Result:** The improvement achieved
A slightly cleaner and more readable `app/main.py` file, properly importing only the required `HTMLResponse` from `fastapi.responses`.

---
*PR created automatically by Jules for task [14659460242648997053](https://jules.google.com/task/14659460242648997053) started by @mohamedhousniphd*