### PR TITLE
🧹 Remove unused Union import from app/auth.py

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -2,7 +2,7 @@
 
 import os
 from datetime import datetime, timedelta
-from typing import Optional, Union
+from typing import Optional
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext


### PR DESCRIPTION
🎯 **What:** Removed the unused `Union` import from the `typing` module in `app/auth.py`.
💡 **Why:** This improves the maintainability and cleanliness of the code by removing dead code, adhering to general code health practices.
✅ **Verification:** Verified that `Union` was not referenced anywhere else in `app/auth.py` via `grep`. Successfully ran a python syntax compilation (`python3 -m py_compile app/auth.py`). Confirmed that there are no tests currently defined in the repository, so none were broken.
✨ **Result:** A cleaner `app/auth.py` file with accurate and necessary imports, preventing potential confusion in the future.

---
*PR created automatically by Jules for task [13329015595221648290](https://jules.google.com/task/13329015595221648290) started by @mohamedhousniphd*