### PR TITLE
🧹 Remove unused reportlab imports in pdf.py

### DIFF
--- a/app/services/pdf.py
+++ b/app/services/pdf.py
@@ -5,13 +5,13 @@ from datetime import datetime
 from typing import Optional
 
 from reportlab.lib.pagesizes import A4, landscape
-from reportlab.lib.units import inch, cm
+from reportlab.lib.units import cm
 from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.platypus import (
-    SimpleDocTemplate, Paragraph, Spacer, Image, Table, TableStyle
+    SimpleDocTemplate, Paragraph, Spacer, Image
 )
-from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_JUSTIFY
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from PIL import Image as PILImage


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`inch`, `Table`, `TableStyle`, `TA_LEFT`) from the `reportlab` library in `app/services/pdf.py`.
💡 **Why:** To improve code maintainability and readability by eliminating dead code and unnecessary dependencies in the file scope.
✅ **Verification:** Ran `python3 -m py_compile app/services/pdf.py` to ensure syntax is valid. Also confirmed there are no breaking changes because the imports were unused in the file.
✨ **Result:** A cleaner `pdf.py` file without unused module references, improving code health without changing behavior.

---
*PR created automatically by Jules for task [10215069473349370378](https://jules.google.com/task/10215069473349370378) started by @mohamedhousniphd*