### PR TITLE
🧹 [code health improvement] Remove unused ValidationError import

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,6 @@ from fastapi import FastAPI, Request, Response, HTTPException, Depends, Form, Bo
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import ValidationError
 
 import asyncio
 


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`from pydantic import ValidationError`) from `app/main.py` at line 11.
💡 **Why:** This improves the maintainability and readability of the codebase by eliminating dead code, keeping the imports clean and purposeful. 
✅ **Verification:** Ran `python3 -m py_compile app/main.py` to ensure syntax validity. Confirmed no module usage broke. Ran the test command (`PYTHONPATH=. pytest`).
✨ **Result:** A slightly cleaner and leaner `main.py` without behavior changes.

---
*PR created automatically by Jules for task [59931639483626365](https://jules.google.com/task/59931639483626365) started by @mohamedhousniphd*