### PR TITLE
🧪 Test: get_multilingual_stopwords fallback paths

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock out modules that aren't available in the test environment
+mock_modules = [
+    'stopwordsiso',
+    'wordcloud',
+    'matplotlib',
+    'matplotlib.pyplot',
+    'arabic_reshaper',
+    'bidi',
+    'bidi.algorithm'
+]
+
+for mod in mock_modules:
+    sys.modules[mod] = MagicMock()
+
+# Configure specific mocks if needed
+sys.modules['matplotlib'].use = MagicMock()

--- a/tests/test_wordcloud.py
+++ b/tests/test_wordcloud.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import patch
+from app.services.wordcloud import get_multilingual_stopwords
+
+def test_get_multilingual_stopwords_happy_path():
+    """Test get_multilingual_stopwords when stopwordsiso returns expected sets."""
+    def mock_stopwords(lang):
+        if lang == 'fr':
+            return {'le', 'la'}
+        elif lang == 'en':
+            return {'the', 'a'}
+        elif lang == 'ar':
+            return {'من', 'إلى'}
+        return set()
+
+    with patch('app.services.wordcloud.stopwords', side_effect=mock_stopwords):
+        stopwords = get_multilingual_stopwords()
+        assert 'le' in stopwords
+        assert 'la' in stopwords
+        assert 'the' in stopwords
+        assert 'a' in stopwords
+        assert 'من' in stopwords
+        assert 'إلى' in stopwords
+
+def test_get_multilingual_stopwords_fallback_path():
+    """Test get_multilingual_stopwords fallback paths when stopwordsiso raises an Exception."""
+    def mock_stopwords_raise(lang):
+        raise Exception(f"Mock exception for {lang}")
+
+    with patch('app.services.wordcloud.stopwords', side_effect=mock_stopwords_raise):
+        stopwords = get_multilingual_stopwords()
+        # Check some French fallback words
+        assert 'le' in stopwords
+        assert 'la' in stopwords
+        assert 'les' in stopwords
+        # Check some English fallback words
+        assert 'the' in stopwords
+        assert 'a' in stopwords
+        assert 'an' in stopwords
+        # Check some Arabic fallback words
+        assert 'من' in stopwords
+        assert 'إلى' in stopwords
+        assert 'على' in stopwords


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tests have been added for the `get_multilingual_stopwords` function in `app/services/wordcloud.py` specifically focusing on testing the fallback lists when `stopwordsiso.stopwords` fails or is unavailable. A `tests/conftest.py` has also been introduced to mock complex application dependencies during test runs.

📊 **Coverage:** What scenarios are now tested
- The happy path (when the `stopwords` module succeeds) is verified.
- The fallback path (when the `stopwords` module raises an Exception) is correctly triggered, and the specific fallback logic sets (French, English, and Arabic stopwords) are verified against the result.

✨ **Result:** The improvement in test coverage
We now have reliable and deterministic unit tests validating the multi-language stopword selection fallback mechanism, ensuring word clouds will still function optimally even if the `stopwordsiso` dictionary loading fails.

---
*PR created automatically by Jules for task [11496333682158006097](https://jules.google.com/task/11496333682158006097) started by @mohamedhousniphd*