### PR TITLE
Refactor `reset_database` to accept teacher_id

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -193,11 +193,15 @@ def increment_device_feedback(device_id: str):
         conn.commit()
 
 
-def reset_database():
-    """Reset the database: delete all feedbacks and device limits."""
+def reset_database(teacher_id: Optional[int] = None):
+    """Reset the database: delete all feedbacks and device limits, or optionally filter by teacher_id."""
     with get_db() as conn:
-        conn.execute("DELETE FROM feedbacks")
-        conn.execute("DELETE FROM device_limits")
+        if teacher_id is not None:
+            conn.execute("DELETE FROM device_limits WHERE device_id IN (SELECT device_id FROM feedbacks WHERE teacher_id = ?)", (teacher_id,))
+            conn.execute("DELETE FROM feedbacks WHERE teacher_id = ?", (teacher_id,))
+        else:
+            conn.execute("DELETE FROM feedbacks")
+            conn.execute("DELETE FROM device_limits")
         conn.commit()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -582,16 +582,12 @@ async def reset_database_endpoint(
     teacher: dict = Depends(get_current_teacher)
 ):
     """Reset the database (teacher only)."""
-    # For now, maybe restrict reset to admin or implement per-teacher reset (delete WHERE teacher_id=...)
-    # Implementing per-teacher delete for safety
-    # TODO: Refactor `reset_database` to accept teacher_id
-    if teacher['is_admin']:
+    if teacher.get('is_admin'):
         reset_database()
         return {"success": True, "message": "Base de données réinitialisée (Admin)"}
     else:
-        # For regular teachers, we might want a different function to clear only their data
-        # For MVP, disabling reset for non-admins to prevent data loss
-        raise HTTPException(status_code=403, detail="Action réservée aux administrateurs")
+        reset_database(teacher['id'])
+        return {"success": True, "message": "Vos données ont été réinitialisées"}
 
 
 @app.get("/api/export/csv")


### PR DESCRIPTION
This commit refactors the `reset_database` function in `app/database.py` to optionally accept a `teacher_id` parameter. When provided, it only deletes feedbacks and device limits associated with that specific teacher, rather than clearing the entire database. 

The `/api/reset` endpoint in `app/main.py` has also been updated to utilize this new functionality. Non-admin teachers can now safely clear their own data, fulfilling the TODO comment and improving data isolation and user autonomy. Admin behavior remains unchanged (they clear the whole database).

---
*PR created automatically by Jules for task [15344178736342934801](https://jules.google.com/task/15344178736342934801) started by @mohamedhousniphd*