### PR TITLE
🔒 Fix hardcoded default SECRET_KEY vulnerability

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,2 @@
+# Security Fix: Hardcoded SECRET_KEY
+Replaced hardcoded fallback `SECRET_KEY` with a dynamically generated secure random string (`secrets.token_hex(32)`) across the codebase. If no environment variable is provided, tokens will be secure but invalidated on process restart, effectively forcing production setups to define `SECRET_KEY` explicitly.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,6 +1,7 @@
 """Authentication logic for Feedny."""
 
 import os
+import secrets
 from datetime import datetime, timedelta
 from typing import Optional, Union
 
@@ -8,7 +9,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 
 # Configuration
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
+SECRET_KEY = os.getenv("SECRET_KEY") or secrets.token_hex(32)
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import ValidationError
 
 import asyncio
+import secrets
 
 # Add parent directory to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -79,7 +80,7 @@ app.add_middleware(
 
 
 # Configuration
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
+SECRET_KEY = os.getenv("SECRET_KEY") or secrets.token_hex(32)
 
 
 # Initialize database on startup


### PR DESCRIPTION
🎯 **What:** The `SECRET_KEY` definition in `app/main.py` and `app/auth.py` fell back to a hardcoded string `"dev-secret-key-change-in-production"` if the environment variable was missing.

⚠️ **Risk:** Any application instance deployed without setting the `SECRET_KEY` environment variable would inadvertently use this known default string. This allows attackers to forge JSON Web Tokens (JWTs) and impersonate any user, completely bypassing authentication. 

🛡️ **Solution:** Replaced the hardcoded string with a securely generated random 32-byte hexadecimal string using the built-in `secrets` module (`secrets.token_hex(32)`). Now, if the environment variable is not defined, tokens will be signed with a dynamic, secure key per process instantiation. This secures the application by default but forces admins to define the environment variable if they require token persistence across server restarts or scaled environments.

---
*PR created automatically by Jules for task [4003074702398604983](https://jules.google.com/task/4003074702398604983) started by @mohamedhousniphd*