### PR TITLE
🧪 Add edge case tests for get_feedbacks_by_ids

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+import pytest
+from app import database
+
+@pytest.fixture(autouse=True)
+def setup_test_db(monkeypatch):
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    monkeypatch.setattr(database, "DATABASE_URL", path)
+    database.init_db()
+    yield
+    os.remove(path)
+
+def test_get_feedbacks_by_ids_empty():
+    result = database.get_feedbacks_by_ids([])
+    assert result == []
+
+def test_get_feedbacks_by_ids_none():
+    result = database.get_feedbacks_by_ids(None)
+    assert result == []
+
+def test_get_feedbacks_by_ids_multiple():
+    # Insert some feedbacks
+    id1 = database.insert_feedback("Feedback 1", "device_1", emotion=1, teacher_id=1)
+    id2 = database.insert_feedback("Feedback 2", "device_2", emotion=2, teacher_id=1)
+    id3 = database.insert_feedback("Feedback 3", "device_3", emotion=3, teacher_id=1)
+
+    result = database.get_feedbacks_by_ids([id1, id3])
+    assert len(result) == 2
+
+    # Sort results by ID to ensure consistent checking
+    result.sort(key=lambda x: x["id"])
+
+    assert result[0]["id"] == id1
+    assert result[0]["content"] == "Feedback 1"
+    assert result[0]["device_id"] == "device_1"
+
+    assert result[1]["id"] == id3
+    assert result[1]["content"] == "Feedback 3"
+    assert result[1]["device_id"] == "device_3"
+
+def test_get_feedbacks_by_ids_invalid_id():
+    # Insert one feedback
+    id1 = database.insert_feedback("Feedback 1", "device_1", emotion=1, teacher_id=1)
+
+    # Request an ID that doesn't exist along with one that does
+    result = database.get_feedbacks_by_ids([id1, 9999])
+
+    assert len(result) == 1
+    assert result[0]["id"] == id1


### PR DESCRIPTION
🎯 **What:** The `get_feedbacks_by_ids` function in `app/database.py` generates dynamic SQL queries based on the length of an input list, but it was previously missing test coverage for edge cases like an empty list, null lists, and mixed valid/invalid inputs.
📊 **Coverage:** A new test file `tests/test_database.py` was created containing:
- `test_get_feedbacks_by_ids_empty`: Verification that an empty list returns an empty list without a SQL syntax error.
- `test_get_feedbacks_by_ids_none`: Verification that `None` returns an empty list safely.
- `test_get_feedbacks_by_ids_multiple`: Verification that providing multiple valid feedback IDs fetches exactly those records and the dynamic placeholders correctly interpolate.
- `test_get_feedbacks_by_ids_invalid_id`: Verification that fetching a mix of valid and non-existent IDs only returns the valid subset.
✨ **Result:** Test coverage specifically for the SQLite dynamic `IN` clause implementation is now robust, reducing the risk of regressions in data retrieval functions.

---
*PR created automatically by Jules for task [11087167622225983692](https://jules.google.com/task/11087167622225983692) started by @mohamedhousniphd*