### PR TITLE
🔒 Remove hardcoded JWT secret key fallback and duplicate variable

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,5 @@
+# Security Patches Learning
+
+- Removed hardcoded default JWT secret key (`dev-secret-key-change-in-production`) which was acting as a fallback for the environment variable `SECRET_KEY`.
+- Used the `secrets` module (`secrets.token_urlsafe(32)`) to securely generate a random default secret key, ensuring environments where the `SECRET_KEY` env var is unassigned remain secure against token forging attacks, though sessions are invalidated on restart.
+- Avoided adding any new external dependencies and maintained the patch strictly within 50 lines.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,6 +1,7 @@
 """Authentication logic for Feedny."""
 
 import os
+import secrets
 from datetime import datetime, timedelta
 from typing import Optional, Union
 
@@ -8,7 +9,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 
 # Configuration
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
+SECRET_KEY = os.getenv("SECRET_KEY", secrets.token_urlsafe(32))
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
 

--- a/app/main.py
+++ b/app/main.py
@@ -79,7 +79,6 @@ app.add_middleware(
 
 
 # Configuration
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
 
 
 # Initialize database on startup

--- a/test_auth.py
+++ b/test_auth.py
@@ -1,0 +1,21 @@
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from app.auth import create_access_token, decode_access_token
+
+def test_auth():
+    print("Testing auth module...")
+    data = {"sub": "test_user"}
+    token = create_access_token(data)
+    print(f"Token created: {token[:20]}...")
+
+    decoded = decode_access_token(token)
+    print(f"Decoded payload: {decoded}")
+
+    assert decoded["sub"] == "test_user"
+    print("Test passed!")
+
+if __name__ == "__main__":
+    test_auth()


### PR DESCRIPTION
🎯 **What:** The `SECRET_KEY` in `app/auth.py` was defaulting to a hardcoded string (`"dev-secret-key-change-in-production"`) when the environment variable was missing. Also, there was a duplicate, unused `SECRET_KEY` definition in `app/main.py`.
⚠️ **Risk:** Hardcoded default secrets allow potential attackers to forge valid JWT tokens if the application is deployed without setting the `SECRET_KEY` environment variable. This could lead to a full authentication bypass and compromise user accounts (teachers/admins).
🛡️ **Solution:** Removed the hardcoded fallback from `app/auth.py` and replaced it with a secure default generated dynamically on runtime via the `secrets` standard library module (`secrets.token_urlsafe(32)`). Cleaned up the duplicate and unused `SECRET_KEY` definition in `app/main.py`. Also documented the security pattern in `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [6545928982939537076](https://jules.google.com/task/6545928982939537076) started by @mohamedhousniphd*