### PR TITLE
🔒 Fix Unrestricted File Upload in Receipt API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -724,6 +724,15 @@ async def upload_receipt(
     
     # Save file
     file_ext = os.path.splitext(file.filename)[1]
+
+    # Validate file extension to prevent unrestricted file upload
+    allowed_extensions = {".png", ".jpg", ".jpeg", ".pdf"}
+    if file_ext.lower() not in allowed_extensions:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Type de fichier non autorisé. Les extensions permises sont: {', '.join(allowed_extensions)}"
+        )
+
     filename = f"{uuid.uuid4()}{file_ext}"
     file_path = f"{UPLOAD_DIR}/{filename}"
     


### PR DESCRIPTION
🎯 **What:** The `upload_receipt` endpoint in `app/main.py` allowed uploading files of any type due to a lack of extension validation. This has been fixed to only accept `.png`, `.jpg`, `.jpeg`, and `.pdf` files.
⚠️ **Risk:** Unrestricted file uploads can lead to Remote Code Execution (RCE) if an attacker uploads malicious scripts (like `.php`, `.py`, `.exe`) that are then executed by the server or downloaded by admins. It also risks hosting malware or phishing content.
🛡️ **Solution:** Implemented a secure allowlist check on the lowercase file extension (`file_ext.lower()`). If the extension is not in `{".png", ".jpg", ".jpeg", ".pdf"}`, the application immediately raises an `HTTPException` with status code 400 and a French localized error message explaining the allowed formats.

---
*PR created automatically by Jules for task [9226892149163467168](https://jules.google.com/task/9226892149163467168) started by @mohamedhousniphd*