### PR TITLE
🔒 Fix hardcoded default JWT secret key

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,9 @@
+# Security Learnings
+
+## Hardcoded Default Secret Keys
+
+**Vulnerability:**
+Using a static default fallback for sensitive material, such as a JWT `SECRET_KEY` (e.g., `os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")`), introduces a severe risk. If the application is deployed to production without properly configuring the environment variable, the predictable default key is used. Attackers can then forge authentication tokens and gain unauthorized access to any account, or even escalate privileges to admin.
+
+**Resolution:**
+The hardcoded fallback was removed. Instead, a dynamically generated random key using `secrets.token_urlsafe(32)` acts as the default if the environment variable is not provided. This ensures that even if developers forget to set the environment variable, the application still uses a highly secure, non-guessable key, preventing malicious actors from forging tokens based on a known default string.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,6 +1,7 @@
 """Authentication logic for Feedny."""
 
 import os
+import secrets
 from datetime import datetime, timedelta
 from typing import Optional, Union
 
@@ -8,7 +9,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 
 # Configuration
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
+SECRET_KEY = os.getenv("SECRET_KEY", secrets.token_urlsafe(32))
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
 

--- a/app/main.py
+++ b/app/main.py
@@ -78,10 +78,6 @@ app.add_middleware(
 )
 
 
-# Configuration
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
-
-
 # Initialize database on startup
 @app.on_event("startup")
 async def startup_event():


### PR DESCRIPTION
🎯 **What:** The hardcoded default fallback string for `SECRET_KEY` was removed and replaced with a dynamic, securely random string generated by `secrets.token_urlsafe(32)`. A duplicate assignment of `SECRET_KEY` in `app/main.py` was also removed.

⚠️ **Risk:** If the application was deployed to production without explicitly configuring the `SECRET_KEY` environment variable, it would fall back to `"dev-secret-key-change-in-production"`. This predictable key allows any attacker to easily forge JWT authentication tokens and gain full unauthorized access (or privilege escalation to admin) to any account.

🛡️ **Solution:** The hardcoded string was removed. By defaulting to `secrets.token_urlsafe(32)`, unconfigured environments will generate a strong, unguessable key at startup. While this will invalidate sessions upon server restart if the environment variable remains unset, it guarantees fail-secure behavior rather than fail-insecure behavior. The unused and duplicate declaration in `app/main.py` was deleted to clean up the codebase.

---
*PR created automatically by Jules for task [2718134573259956905](https://jules.google.com/task/2718134573259956905) started by @mohamedhousniphd*