### PR TITLE
🧪 Add tests for verify_password in app/auth.py

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,31 @@
+import pytest
+from app.auth import verify_password, get_password_hash
+
+def test_verify_password_correct():
+    """Test that a correct password matches its hash."""
+    password = "supersecretpassword123"
+    hashed = get_password_hash(password)
+    assert verify_password(password, hashed) is True
+
+def test_verify_password_incorrect():
+    """Test that an incorrect password does not match the hash."""
+    password = "supersecretpassword123"
+    wrong_password = "wrongpassword"
+    hashed = get_password_hash(password)
+    assert verify_password(wrong_password, hashed) is False
+
+def test_verify_password_empty_string():
+    """Test empty string behavior."""
+    password = ""
+    hashed = get_password_hash(password)
+    assert verify_password(password, hashed) is True
+    assert verify_password("notempty", hashed) is False
+
+def test_verify_password_type_handling():
+    """Test behavior with non-string inputs.
+    We expect it to raise an exception like TypeError, depending on the underlying passlib implementation.
+    """
+    hashed = get_password_hash("password")
+
+    with pytest.raises(Exception):
+        verify_password(12345, hashed)


### PR DESCRIPTION
🎯 **What:** The testing gap for `verify_password` and `get_password_hash` in `app/auth.py` has been addressed by adding a new test suite in `tests/test_auth.py`.

📊 **Coverage:** The new tests cover:
- Happy paths: Verifying that a correct password matches its generated hash.
- Negative paths: Verifying that an incorrect password does not match the hash.
- Edge cases: Handling of empty strings.
- Error conditions: Ensuring that passing non-string inputs (like integers) raises an Exception (as expected from the underlying `passlib` implementation).

✨ **Result:** The improvement adds critical unit test coverage for the core authentication logic, increasing reliability and preventing future regressions in password verification.

---
*PR created automatically by Jules for task [701214482347757287](https://jules.google.com/task/701214482347757287) started by @mohamedhousniphd*