### PR TITLE
🧹 Make credit amount configurable for receipt approval

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -781,6 +781,7 @@ async def list_receipts(
 @app.post("/api/admin/receipts/{receipt_id}/approve")
 async def approve_receipt(
     receipt_id: int,
+    credits: Optional[int] = None,
     teacher: dict = Depends(get_current_teacher)
 ):
     """Approve a receipt and add credits (Admin only)."""
@@ -796,14 +797,14 @@ async def approve_receipt(
     if receipt['status'] == 'approved':
         return {"status": "success", "message": "Déjà approuvé"}
         
-    # Approve and add credits (e.g., 5 credits per valid payment)
-    # TODO: Make credit amount configurable or part of the request
-    CREDITS_PER_PAYMENT = 10 
+    # Approve and add credits
+    if credits is None:
+        credits = int(os.getenv("CREDITS_PER_PAYMENT", "10"))
     
     update_receipt_status(receipt_id, 'approved')
-    add_credits(receipt['teacher_id'], CREDITS_PER_PAYMENT)
+    add_credits(receipt['teacher_id'], credits)
     
-    return {"status": "success", "message": f"Reçu validé, {CREDITS_PER_PAYMENT} crédits ajoutés"}
+    return {"status": "success", "message": f"Reçu validé, {credits} crédits ajoutés"}
 
 
 @app.post("/api/admin/receipts/{receipt_id}/reject")

--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -206,9 +206,16 @@
         }
 
         async function approveReceipt(id) {
-            if (!confirm('Valider ce paiement et ajouter 10 crédits ?')) return;
+            const credits = prompt('Combien de crédits souhaitez-vous ajouter pour ce paiement ?', '10');
+            if (credits === null) return; // User cancelled
+            const parsedCredits = parseInt(credits);
+            if (isNaN(parsedCredits) || parsedCredits <= 0) {
+                alert('Veuillez entrer un nombre valide de crédits.');
+                return;
+            }
+            if (!confirm(`Valider ce paiement et ajouter ${parsedCredits} crédits ?`)) return;
             try {
-                const response = await fetch(`/api/admin/receipts/${id}/approve`, { method: 'POST' });
+                const response = await fetch(`/api/admin/receipts/${id}/approve?credits=${parsedCredits}`, { method: 'POST' });
                 if (response.ok) loadReceipts();
             } catch (e) { alert('Erreur'); }
         }


### PR DESCRIPTION
🎯 **What:** Modified the `approve_receipt` endpoint to accept the number of credits to award as an optional query parameter. If omitted, it falls back to the `CREDITS_PER_PAYMENT` environment variable, defaulting to 10. The frontend was also updated to prompt the admin for this amount before sending the request.

💡 **Why:** Hardcoding business logic like `CREDITS_PER_PAYMENT = 10` directly inside endpoint handlers hurts maintainability and flexibility. Extracting this to a dynamic parameter and environment variable allows operators to adjust pricing or rewards without modifying the application source code.

✅ **Verification:**
1. Ran `python3 -m py_compile app/main.py` to ensure no syntax errors were introduced.
2. Verified the file diff to ensure the fallback logic and typing were implemented correctly and safely.
3. Received approval from the automated code review agent confirming the changes are safe and backwards-compatible.

✨ **Result:** The system is now more flexible, allowing admins to dynamically reward different credit amounts per receipt, and allowing operators to configure the baseline reward via environment variables without code changes.

---
*PR created automatically by Jules for task [11246051334804967635](https://jules.google.com/task/11246051334804967635) started by @mohamedhousniphd*