### PR TITLE
🔒 Fix CWE-798 Hardcoded default password in sync_admin_account

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## Security Patch: CWE-798 Hard-coded Credentials in sync_admin_account
+- **Issue**: The application used a hardcoded default string 'password123' for the admin account if the TEACHER_PASSWORD environment variable was not set, unconditionally updating it on server startup.
+- **Solution**: Updated sync_admin_account to check the environment variable. If missing, it uses secrets.token_urlsafe(16) to generate a secure random password on first run and logs it, while ensuring it no longer overwrites an existing admin password on subsequent startups if the env var is omitted.
+- **Learnings**: Avoid hardcoded default passwords for critical accounts. Default fallbacks should be dynamically generated secure secrets or the application should fail to start if required security credentials are missing. Unconditional password resets on startup based on missing variables leads to persistent weak credential exposure.

--- a/app/main.py
+++ b/app/main.py
@@ -91,13 +91,22 @@ async def startup_event():
 def sync_admin_account():
     """Ensure the main admin account exists and matches environment variables."""
     admin_email = "mohamedhousni@afeedny.com"
-    # Read password from environment, default to 'password123' if not set
-    admin_password = os.getenv("TEACHER_PASSWORD", "password123")
     
-    admin_hash = get_password_hash(admin_password)
+    # Read password from environment
+    env_password = os.getenv("TEACHER_PASSWORD")
     
     existing = get_teacher_by_email(admin_email)
+
     if not existing:
+        if env_password:
+            admin_password = env_password
+        else:
+            import secrets
+            admin_password = secrets.token_urlsafe(16)
+            print(f"WARNING: TEACHER_PASSWORD not set. Generated secure random password for admin '{admin_email}': {admin_password}")
+
+        admin_hash = get_password_hash(admin_password)
+
         # Create default admin with a fixed code
         create_teacher("Mohamed HOUSNI", admin_email, admin_hash, "ADMIN", is_admin=True)
         # We don't have the ID here directly without re-querying, 
@@ -107,8 +116,10 @@ def sync_admin_account():
         if new_admin:
             add_credits(new_admin['id'], 1000)
     else:
-        # Check if password needs synchronization (or just update it to be safe)
-        update_teacher_password(admin_email, admin_hash)
+        # Only update the password if explicitly set in the environment
+        if env_password:
+            admin_hash = get_password_hash(env_password)
+            update_teacher_password(admin_email, admin_hash)
 
 
 def get_device_id(request: Request) -> str:


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in `sync_admin_account` (app/main.py) where the default string 'password123' was used as the admin fallback if the `TEACHER_PASSWORD` environment variable was missing.

⚠️ **Risk:** The previous implementation not only used a highly predictable, weak default password (`password123`) for the main admin account when the environment variable wasn't set, but it also unconditionally overwrote the existing admin's password with this weak default on every server restart. This creates a critical CWE-798 (Use of Hard-coded Credentials) vulnerability, easily leading to unauthorized access.

🛡️ **Solution:** The application now checks for `TEACHER_PASSWORD`. If it's absent and the admin account does not exist, it generates a secure random password using `secrets.token_urlsafe(16)` and logs it to the console. Furthermore, if the admin account already exists, its password is *only* updated if `TEACHER_PASSWORD` is explicitly provided, preventing the system from unintentionally wiping out an existing admin password on restart.

---
*PR created automatically by Jules for task [10981148835491816322](https://jules.google.com/task/10981148835491816322) started by @mohamedhousniphd*