### PR TITLE
🧹 Refactor reset_database to support per-teacher delete

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -193,11 +193,27 @@ def increment_device_feedback(device_id: str):
         conn.commit()
 
 
-def reset_database():
-    """Reset the database: delete all feedbacks and device limits."""
+def reset_database(teacher_id: int):
+    """Reset the database for a specific teacher: delete their feedbacks and update limits."""
     with get_db() as conn:
-        conn.execute("DELETE FROM feedbacks")
-        conn.execute("DELETE FROM device_limits")
+        cursor = conn.execute(
+            "SELECT device_id, COUNT(*) as count FROM feedbacks WHERE teacher_id = ? GROUP BY device_id",
+            (teacher_id,)
+        )
+        device_counts = cursor.fetchall()
+
+        conn.execute("DELETE FROM feedbacks WHERE teacher_id = ?", (teacher_id,))
+
+        for row in device_counts:
+            conn.execute(
+                """
+                UPDATE device_limits
+                SET feedback_count = MAX(0, feedback_count - ?)
+                WHERE device_id = ?
+                """,
+                (row["count"], row["device_id"])
+            )
+
         conn.commit()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -582,16 +582,8 @@ async def reset_database_endpoint(
     teacher: dict = Depends(get_current_teacher)
 ):
     """Reset the database (teacher only)."""
-    # For now, maybe restrict reset to admin or implement per-teacher reset (delete WHERE teacher_id=...)
-    # Implementing per-teacher delete for safety
-    # TODO: Refactor `reset_database` to accept teacher_id
-    if teacher['is_admin']:
-        reset_database()
-        return {"success": True, "message": "Base de données réinitialisée (Admin)"}
-    else:
-        # For regular teachers, we might want a different function to clear only their data
-        # For MVP, disabling reset for non-admins to prevent data loss
-        raise HTTPException(status_code=403, detail="Action réservée aux administrateurs")
+    reset_database(teacher['id'])
+    return {"success": True, "message": "Base de données réinitialisée"}
 
 
 @app.get("/api/export/csv")


### PR DESCRIPTION
🎯 **What:** The `reset_database` function was refactored to accept a `teacher_id`, allowing teachers to safely delete only their own feedbacks instead of wiping the entire database.

💡 **Why:** The previous implementation restricted the reset functionality to admins and deleted all feedbacks and device limits indiscriminately. This refactor makes the codebase more robust and maintainable by correctly scoping deletions and properly decrementing the `device_limits` counts for the affected devices.

✅ **Verification:** Ran syntax checks on modified files (`app/database.py` and `app/main.py`). Executed a temporary Python script connecting to an in-memory test database, which validated that resetting one teacher's feedbacks appropriately decremented the associated device's feedback count and left other teachers' feedbacks untouched.

✨ **Result:** A safer, more secure multi-tenant reset process, allowing normal teachers to clear their data without affecting others.

---
*PR created automatically by Jules for task [15885067865310507329](https://jules.google.com/task/15885067865310507329) started by @mohamedhousniphd*