### PR TITLE
🧪 [Testing Improvement] Add unit tests for process_arabic_word function

### DIFF
--- a/app/tests/test_wordcloud.py
+++ b/app/tests/test_wordcloud.py
@@ -1,0 +1,55 @@
+import pytest
+import sys
+from unittest.mock import patch, MagicMock
+
+# Import dependencies safely. They might be mocked by conftest if missing.
+from app.services.wordcloud import process_arabic_word
+
+def test_process_arabic_word_empty_string():
+    assert process_arabic_word("") == ""
+
+def test_process_arabic_word_non_arabic():
+    assert process_arabic_word("hello") == "hello"
+    assert process_arabic_word("12345") == "12345"
+    assert process_arabic_word("bonjour") == "bonjour"
+    assert process_arabic_word("!@#$%") == "!@#$%"
+
+@patch('app.services.wordcloud.arabic_reshaper.ArabicReshaper')
+@patch('app.services.wordcloud.get_display')
+def test_process_arabic_word_arabic(mock_get_display, mock_arabic_reshaper):
+    word = "مرحبا"
+
+    mock_reshaper_instance = MagicMock()
+    mock_arabic_reshaper.return_value = mock_reshaper_instance
+    mock_reshaper_instance.reshape.return_value = "reshaped_word"
+    mock_get_display.return_value = "bidi_word"
+
+    result = process_arabic_word(word)
+
+    # Verify the config was passed correctly based on the actual source code
+    mock_arabic_reshaper.assert_called_once_with(configuration={
+        'delete_harakat': True,
+        'delete_tatweel': True,
+        'support_ligatures': True,
+        'shift_harakat_position': False
+    })
+
+    mock_reshaper_instance.reshape.assert_called_once_with(word)
+    mock_get_display.assert_called_once_with("reshaped_word")
+    assert result == "bidi_word"
+
+@patch('app.services.wordcloud.arabic_reshaper.ArabicReshaper')
+@patch('app.services.wordcloud.get_display')
+def test_process_arabic_word_mixed(mock_get_display, mock_arabic_reshaper):
+    word = "helloمرحبا"
+
+    mock_reshaper_instance = MagicMock()
+    mock_arabic_reshaper.return_value = mock_reshaper_instance
+    mock_reshaper_instance.reshape.return_value = "reshaped_word"
+    mock_get_display.return_value = "bidi_word"
+
+    result = process_arabic_word(word)
+
+    mock_reshaper_instance.reshape.assert_called_once_with(word)
+    mock_get_display.assert_called_once_with("reshaped_word")
+    assert result == "bidi_word"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `process_arabic_word` function in `app/services/wordcloud.py`.

📊 **Coverage:** The tests now cover scenarios where the text is empty, contains only non-Arabic characters, contains only Arabic characters, and contains a mix of both. Mocks are used to ensure the Arabic text is correctly parsed and passed to `arabic_reshaper` with the correct configuration and then reshaped correctly using `bidi.algorithm`.

✨ **Result:** The improvement in test coverage guarantees the stability of the core text processing function for Arabic Nuage de mots rendering, without introducing destructive global side-effects.

---
*PR created automatically by Jules for task [17266085866698760586](https://jules.google.com/task/17266085866698760586) started by @mohamedhousniphd*