### PR TITLE
🧪 Add tests for decode_access_token

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,44 @@
+import pytest
+from datetime import timedelta
+from unittest.mock import patch
+
+from app.auth import create_access_token, decode_access_token, JWTError
+
+@patch("app.auth.jwt.decode")
+@patch("app.auth.jwt.encode")
+def test_decode_access_token_valid(mock_encode, mock_decode):
+    """Test decoding a valid access token."""
+    mock_encode.return_value = "mocked.token.string"
+    mock_decode.return_value = {"sub": "testuser", "exp": 1234567890}
+
+    data = {"sub": "testuser"}
+    token = create_access_token(data)
+    decoded = decode_access_token(token)
+
+    assert decoded is not None
+    assert decoded["sub"] == "testuser"
+    assert "exp" in decoded
+
+@patch("app.auth.jwt.decode")
+def test_decode_access_token_invalid_string(mock_decode):
+    """Test decoding an invalid string."""
+    mock_decode.side_effect = JWTError("Invalid token")
+
+    token = "invalid.token.string"
+    decoded = decode_access_token(token)
+
+    assert decoded is None
+
+@patch("app.auth.jwt.decode")
+@patch("app.auth.jwt.encode")
+def test_decode_access_token_expired(mock_encode, mock_decode):
+    """Test decoding an expired access token."""
+    mock_encode.return_value = "mocked.expired.token"
+    mock_decode.side_effect = JWTError("Signature has expired")
+
+    data = {"sub": "testuser"}
+    # Create a token that expired 15 minutes ago
+    token = create_access_token(data, expires_delta=timedelta(minutes=-15))
+    decoded = decode_access_token(token)
+
+    assert decoded is None


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `decode_access_token` function in `app/auth.py` was missing tests. This PR introduces a test file that specifically targets this function to ensure it behaves correctly under different scenarios.

📊 **Coverage:** What scenarios are now tested
- **Valid token:** Ensures `decode_access_token` correctly returns the expected payload when `jwt.decode` succeeds.
- **Invalid token string:** Ensures `decode_access_token` catches `JWTError` and gracefully returns `None` when given a malformed token.
- **Expired token:** Ensures `decode_access_token` properly handles expired token exceptions (via `JWTError` for expired signatures) and returns `None`.

✨ **Result:** The improvement in test coverage
The `decode_access_token` function is now fully tested using properly isolated mocks (`unittest.mock.patch` on `jwt.decode` and `jwt.encode`). This prevents bugs when refactoring authentication logic and strictly verifies the `JWTError` handling.

---
*PR created automatically by Jules for task [17176346573471923151](https://jules.google.com/task/17176346573471923151) started by @mohamedhousniphd*