### PR TITLE
🔒 Fix overly permissive CORS configuration

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,1 @@
+CORS with credentials must not use a wildcard. Use environment variables to dynamically allow specific origins, falling back to an empty list (most restrictive) for secure defaults.

--- a/PR_description.md
+++ b/PR_description.md
@@ -1,0 +1,5 @@
+## Description
+
+🎯 **What:** The vulnerability fixed was an overly permissive CORS configuration that allowed any origin (`["*"]`) while also allowing credentials (`allow_credentials=True`).
+⚠️ **Risk:** If left unfixed, this exposes the application to Cross-Site Request Forgery (CSRF) and cross-origin data theft, as malicious sites could make authenticated requests on behalf of users.
+🛡️ **Solution:** The fix replaces the hardcoded `["*"]` wildcard with a dynamic configuration that reads the `ALLOWED_ORIGINS` environment variable, splits it into a list, and uses it for the `CORSMiddleware`. This allows administrators to specify an exact list of allowed origins or fall back to an empty list (most restrictive) if unset.

--- a/app/main.py
+++ b/app/main.py
@@ -69,9 +69,12 @@ app = FastAPI(title="Feedny", version="1.0.0")
 
 
 # CORS middleware
+allowed_origins_str = os.getenv("ALLOWED_ORIGINS", "")
+allowed_origins = [origin.strip() for origin in allowed_origins_str.split(",")] if allowed_origins_str else []
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Description

🎯 **What:** The vulnerability fixed was an overly permissive CORS configuration that allowed any origin (`["*"]`) while also allowing credentials (`allow_credentials=True`).
⚠️ **Risk:** If left unfixed, this exposes the application to Cross-Site Request Forgery (CSRF) and cross-origin data theft, as malicious sites could make authenticated requests on behalf of users.
🛡️ **Solution:** The fix replaces the hardcoded `["*"]` wildcard with a dynamic configuration that reads the `ALLOWED_ORIGINS` environment variable, splits it into a list, and uses it for the `CORSMiddleware`. This allows administrators to specify an exact list of allowed origins or fall back to an empty list (most restrictive) if unset.

---
*PR created automatically by Jules for task [8789283783587299337](https://jules.google.com/task/8789283783587299337) started by @mohamedhousniphd*