### PR TITLE
🔒 Fix unrestricted file upload vulnerability in receipt API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Thumbs.db
 
 # Docker
 docker-compose.override.yml
+app/static/uploads/receipts/*

--- a/app/main.py
+++ b/app/main.py
@@ -723,7 +723,15 @@ async def upload_receipt(
     os.makedirs(UPLOAD_DIR, exist_ok=True)
     
     # Save file
-    file_ext = os.path.splitext(file.filename)[1]
+    file_ext = os.path.splitext(file.filename)[1].lower()
+    allowed_extensions = ['.png', '.jpg', '.jpeg', '.pdf']
+
+    if file_ext not in allowed_extensions:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Format de fichier non autorisé. Les formats acceptés sont: {', '.join(allowed_extensions)}"
+        )
+
     filename = f"{uuid.uuid4()}{file_ext}"
     file_path = f"{UPLOAD_DIR}/{filename}"
     

--- a/test_upload.py
+++ b/test_upload.py
@@ -1,0 +1,50 @@
+import os
+import io
+from fastapi.testclient import TestClient
+from app.main import app, get_current_teacher
+from app.database import init_db, create_teacher, get_teacher_by_email
+
+# Set up test database or ensure tables exist
+def setup_test_db():
+    init_db()
+    teacher = get_teacher_by_email("test_upload@example.com")
+    if not teacher:
+        create_teacher("Test Upload", "test_upload@example.com", "dummy_hash", "TUP123")
+    return get_teacher_by_email("test_upload@example.com")
+
+def override_get_current_teacher():
+    teacher = setup_test_db()
+    if teacher:
+        return teacher
+    return {"id": 1, "email": "test@example.com", "name": "Test Teacher"}
+
+app.dependency_overrides[get_current_teacher] = override_get_current_teacher
+
+client = TestClient(app)
+
+def test_upload_allowed_extension():
+    # Test uploading a .pdf file
+    file_content = b"Dummy PDF content"
+    files = {"file": ("test_receipt.pdf", io.BytesIO(file_content), "application/pdf")}
+
+    response = client.post("/api/payment/upload", files=files)
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    print("Allowed extension test passed!")
+
+def test_upload_disallowed_extension():
+    # Test uploading a .txt file
+    file_content = b"Dummy TXT content"
+    files = {"file": ("test_receipt.txt", io.BytesIO(file_content), "text/plain")}
+
+    response = client.post("/api/payment/upload", files=files)
+
+    assert response.status_code == 400
+    assert "Format de fichier non autorisé" in response.json()["detail"]
+    print("Disallowed extension test passed!")
+
+if __name__ == "__main__":
+    test_upload_allowed_extension()
+    test_upload_disallowed_extension()
+    print("All tests passed!")


### PR DESCRIPTION
🎯 **What:** The `upload_receipt` endpoint previously allowed any file type to be uploaded to the `app/static/uploads/receipts` directory. This has been fixed to strictly allow only `.png`, `.jpg`, `.jpeg`, and `.pdf` files.
⚠️ **Risk:** Unrestricted file uploads can lead to Remote Code Execution (RCE) if an attacker uploads a malicious executable script (e.g., a `.py` file if executed by the backend, or malicious HTML/JS leading to XSS if served directly).
🛡️ **Solution:** The fix checks the lowercase file extension against a whitelist of safe document types. If the file is not allowed, it immediately rejects the request with a 400 Bad Request error. Furthermore, generating a new UUID-based filename ensures the safe storage and retrieval of the files while avoiding path traversal vulnerabilities. Added the static upload directory to `.gitignore` to avoid checking in dynamic files. Added tests via `test_upload.py`.

---
*PR created automatically by Jules for task [16288746560374429428](https://jules.google.com/task/16288746560374429428) started by @mohamedhousniphd*