### PR TITLE
🧹 [code health improvement] Extract hardcoded API device limit to constant

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -7,6 +7,9 @@ import uuid
 
 DATABASE_URL = "feedny.db"
 
+# Device feedback limit configuration
+DEVICE_FEEDBACK_LIMIT = 1
+
 
 @contextmanager
 def get_db():
@@ -176,7 +179,7 @@ def check_device_limit(device_id: str) -> tuple[bool, int]:
         row = cursor.fetchone()
         if row:
             count = row["feedback_count"]
-            return (count == 0, count)
+            return (count < DEVICE_FEEDBACK_LIMIT, count)
         return (True, 0)
 
 


### PR DESCRIPTION
🎯 **What:** The hardcoded logic evaluating `count == 0` in `check_device_limit` (which effectively set the feedback limit to 1) was extracted to a top-level constant `DEVICE_FEEDBACK_LIMIT = 1`. The function now checks if `count < DEVICE_FEEDBACK_LIMIT`.

💡 **Why:** Centralizing configuration values like API/device limits at the top of the file improves code readability and maintainability. It makes it obvious where to change the limit in the future without having to hunt down logic buried within a function.

✅ **Verification:** I verified the change by manually inspecting the code to ensure the functional logic remains identical (since `count < 1` is functionally equivalent to `count == 0` for this use case where count is incremented positively). The syntax was verified to ensure no errors were introduced.

✨ **Result:** The codebase is now cleaner, and the configuration logic for device limits is centralized and maintainable.

---
*PR created automatically by Jules for task [4017078599269656088](https://jules.google.com/task/4017078599269656088) started by @mohamedhousniphd*